### PR TITLE
refactor(browser): use browser-friendly dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,12 @@
  * Module dependencies
  */
 
-var assert = require('assert');
+var assert = require('assert-error');
+var isString = require('lodash.isstring');
+
+var STRING_ERROR_TEXT = 'whitespace-remove: val should be a string';
+var EMPTY_STRING = '';
+var REMOVE_WHITESPACE_REGEX = /( )/gm;
 
 /**
  * Strip all newlines from the given value
@@ -12,7 +17,7 @@ var assert = require('assert');
  * @api public
  */
 
-module.exports = function removeNewlines(val) {
-  assert.equal(typeof val, 'string', 'whitespace-remove: val should be a string');
-  return val.replace(/( )/gm, '');
-}
+module.exports = function removeWhitespace(val) {
+  assert(isString(val), new TypeError(STRING_ERROR_TEXT));
+  return val.replace(REMOVE_WHITESPACE_REGEX, EMPTY_STRING);
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "string"
   ],
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "assert-error": "^1.0.3",
+    "lodash.isstring": "^3.0.1"
+  },
   "devDependencies": {
     "istanbul": "^0.3.2",
     "make-lint": "^1.0.1",

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ var remove = require('./index');
  * Test
  */
 
-describe('newline-remove', function() {
+describe('whitespace-remove', function() {
   it('should assert argument types', function() {
     remove.bind(remove, 123)
       .should.throw('whitespace-remove: val should be a string');
@@ -19,5 +19,5 @@ describe('newline-remove', function() {
   it('should strip all whitespace from the string', function() {
     var val = 'foo \n bar \r \n bla bla bla bla';
     remove(val).should.eql('foo\nbar\r\nblablablabla');
-  })
+  });
 });


### PR DESCRIPTION
The motivation is to use this package with browserify (or similar) and have a more lightweight bundle.

Potential breaking change:
- Throws `TypeError` instead of `AssertionError`.
