### PR TITLE
chore(package): repository address

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "make test"
   },
-  "repository": "undefined/whitespace-remove",
+  "repository": "yoshuawuyts/whitespace-remove",
   "keywords": [
     "strip",
     "remove",


### PR DESCRIPTION
The github address in https://www.npmjs.com/package/whitespace-remove goes to a 404
